### PR TITLE
Update Interval Timer

### DIFF
--- a/Interval Timer
+++ b/Interval Timer
@@ -24,29 +24,26 @@ Public Class Form1
     Private Sub Timer1_Tick(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles Timer1.Tick
         tbZähler.Text = tbZähler.Text + 1
     End Sub
+    
     ' Minuten und Sekunden Aktiv
-    Dim AktivMinuten As Integer = tbAktiv.Text * 60000
-    Dim AktivSekunden As Integer = tbAktiv.Text * 1000
-
     Private Sub rbaktsek_CheckedChanged(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles rbaktsek.CheckedChanged
         If rbaktmin.Checked = True Then
-            Timer1.Interval = AktivMinuten
+            Timer1.Interval = 60000
         ElseIf rbaktsek.Checked = True Then
-            Timer1.Interval = AktivSekunden
+            Timer1.Interval = 10000
         End If
     End Sub
     ' Timer für passive Phase
     Private Sub Timer2_Tick(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles Timer2.Tick
         tbZähler.Text = tbZähler.Text + 1
     End Sub
+    
     ' Minuten und Sekunden Passiv
-    Dim PassivMinuten As Integer = tbPassiv.Text * 60000
-    Dim PassivSekunden As Integer = tbPassiv.Text * 1000
     Private Sub rbpassek_CheckedChanged(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles rbpassek.CheckedChanged
         If rbpassmin.Checked = True Then
-            Timer2.Interval = PassivMinuten
+            Timer2.Interval = 60000
         ElseIf rbpassek.Checked = True Then
-            Timer2.Interval = PassivSekunden
+            Timer2.Interval = 1000
         End If
     End Sub
     'Zähler und Umschaltung aktiv/passiv


### PR DESCRIPTION
Interval war falsch. Timer muss langsamer zählen wenn es um Minuten geht, jedoch unabhänging von den Anzahl eingestellter Minuten.

Problem jetzt: Zähler zeigt bei Minutenintervallen nur noch volle Minuten an. Da das Ding eh noch nicht läuft, ist das jedoch sekundär... Eventuell lösen mit einem zweigeteilten Zähler:
ticktimer = tbzähler2 + 1
if tbzähler2=60 then tbzähler1+1 and tbzähler2.clear
endif
Dann abhänging vom radiobutton die bedingung ob der Timer auf die zweite oder erste zählerbox achtet. Jedoch: Keine Intervalle von halben Minuten möglich. Nur sekunden bis 60 oder ganze Minuten... Da führt das eine zum nächsten.